### PR TITLE
Switch dependency format

### DIFF
--- a/tdtree-bench/build.gradle
+++ b/tdtree-bench/build.gradle
@@ -17,7 +17,7 @@ shadowJar {
 
 dependencies {
     compile project(":tdtree")
-    compile group: 'org.openjdk.jmh', name: 'jmh-core', version: jmhVersion
-    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
-    annotationProcessor group: 'org.openjdk.jmh', name: 'jmh-generator-annprocess', version: jmhVersion
+    compile("org.openjdk.jmh:jmh-core:${jmhVersion}")
+    compile("org.slf4j:slf4j-simple:1.7.30")
+    annotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:${jmhVersion}")
 }


### PR DESCRIPTION
Switch to the inline dependency version, to see if dependabot picks it up.